### PR TITLE
Feature/caregiver/internal

### DIFF
--- a/caregiver-service/src/main/java/com/carenest/business/caregiverservice/application/service/CaregiverService.java
+++ b/caregiver-service/src/main/java/com/carenest/business/caregiverservice/application/service/CaregiverService.java
@@ -23,4 +23,6 @@ public interface CaregiverService {
 	void deleteCaregiver(UUID caregiverId);
 
 	Page<CaregiverSearchResponseServiceDTO> searchCaregiver(String location, String service, Pageable pageable);
+
+	void updateCaregiverStatus(UUID id, boolean approvalStatusCheck);
 }

--- a/caregiver-service/src/main/java/com/carenest/business/caregiverservice/application/service/CaregiverServiceImpl.java
+++ b/caregiver-service/src/main/java/com/carenest/business/caregiverservice/application/service/CaregiverServiceImpl.java
@@ -16,7 +16,6 @@ import com.carenest.business.caregiverservice.application.dto.response.Caregiver
 import com.carenest.business.caregiverservice.application.dto.response.CaregiverSearchResponseServiceDTO;
 import com.carenest.business.caregiverservice.application.dto.response.CaregiverUpdateResponseServiceDTO;
 import com.carenest.business.caregiverservice.domain.model.Caregiver;
-import com.carenest.business.caregiverservice.domain.model.GenderType;
 import com.carenest.business.caregiverservice.domain.model.category.CategoryLocation;
 import com.carenest.business.caregiverservice.domain.model.category.CategoryService;
 import com.carenest.business.caregiverservice.domain.service.CaregiverDomainService;
@@ -156,6 +155,15 @@ public class CaregiverServiceImpl implements CaregiverService {
 			caregiver.getPricePerDay(),
 			caregiver.getGender()
 		));
+	}
+
+	@Override
+	@Transactional
+	public void updateCaregiverStatus(UUID id, boolean approvalStatusCheck) {
+		Caregiver caregiver = caregiverRepository.findById(id).orElseThrow(()->
+			new CaregiverException(ErrorCode.NOT_FOUND));
+
+		caregiverDomainService.caregiverApprovalStatusCheck(caregiver,approvalStatusCheck);
 	}
 
 }

--- a/caregiver-service/src/main/java/com/carenest/business/caregiverservice/domain/model/Caregiver.java
+++ b/caregiver-service/src/main/java/com/carenest/business/caregiverservice/domain/model/Caregiver.java
@@ -45,7 +45,7 @@ public class Caregiver extends BaseEntity {
 	private UUID id;
 
 	// 간병인 생성할때 매핑
-	@Column(name = "user_id")
+	@Column(name = "user_id",unique = true)
 	private UUID userId;
 
 	@OneToMany(mappedBy = "caregiver", cascade = CascadeType.ALL, orphanRemoval = true)
@@ -82,5 +82,9 @@ public class Caregiver extends BaseEntity {
 
 	public void clearCategoryLocation() {
 		this.caregiverCategoryLocations.clear();
+	}
+
+	public void updateApprovalStatus(boolean check) {
+		this.approvalStatus = check;
 	}
 }

--- a/caregiver-service/src/main/java/com/carenest/business/caregiverservice/domain/service/CaregiverDomainService.java
+++ b/caregiver-service/src/main/java/com/carenest/business/caregiverservice/domain/service/CaregiverDomainService.java
@@ -17,4 +17,6 @@ public interface CaregiverDomainService {
 
 	void updateCaregiverCategories(Caregiver caregiver, List<CategoryService> categoryServices,
 		List<CategoryLocation> categoryLocations);
+
+	void caregiverApprovalStatusCheck(Caregiver caregiver, boolean check);
 }

--- a/caregiver-service/src/main/java/com/carenest/business/caregiverservice/domain/service/CaregiverDomainServiceImpl.java
+++ b/caregiver-service/src/main/java/com/carenest/business/caregiverservice/domain/service/CaregiverDomainServiceImpl.java
@@ -90,6 +90,11 @@ public class CaregiverDomainServiceImpl implements CaregiverDomainService {
 	}
 
 	@Override
+	public void caregiverApprovalStatusCheck(Caregiver caregiver, boolean check) {
+		caregiver.updateApprovalStatus(check);
+	}
+
+	@Override
 	public void deleteCaregiverWithAssociations(UUID caregiverId, Caregiver caregiver) {
 		caregiver.clearCategoryServices();
 		caregiver.clearCategoryLocation();

--- a/caregiver-service/src/main/java/com/carenest/business/caregiverservice/presentation/controller/CaregiverController.java
+++ b/caregiver-service/src/main/java/com/carenest/business/caregiverservice/presentation/controller/CaregiverController.java
@@ -20,13 +20,13 @@ import com.carenest.business.caregiverservice.application.dto.response.Caregiver
 import com.carenest.business.caregiverservice.application.dto.response.CaregiverReadResponseServiceDTO;
 import com.carenest.business.caregiverservice.application.dto.response.CaregiverSearchResponseServiceDTO;
 import com.carenest.business.caregiverservice.application.dto.response.CaregiverUpdateResponseServiceDTO;
-import com.carenest.business.caregiverservice.application.service.CaregiverServiceImpl;
-import com.carenest.business.caregiverservice.presentation.dto.response.CaregiverSearchResponseDTO;
-import com.carenest.business.caregiverservice.presentation.dto.request.CaregiverUpdateRequestDTO;
-import com.carenest.business.caregiverservice.presentation.dto.response.CaregiverReadResponseDTO;
+import com.carenest.business.caregiverservice.application.service.CaregiverService;
 import com.carenest.business.caregiverservice.presentation.dto.mapper.CaregiverPresentationMapper;
 import com.carenest.business.caregiverservice.presentation.dto.request.CaregiverCreateRequestDTO;
+import com.carenest.business.caregiverservice.presentation.dto.request.CaregiverUpdateRequestDTO;
 import com.carenest.business.caregiverservice.presentation.dto.response.CaregiverCreateResponseDTO;
+import com.carenest.business.caregiverservice.presentation.dto.response.CaregiverReadResponseDTO;
+import com.carenest.business.caregiverservice.presentation.dto.response.CaregiverSearchResponseDTO;
 import com.carenest.business.caregiverservice.presentation.dto.response.CaregiverUpdateResponseDTO;
 import com.carenest.business.caregiverservice.util.PageableUtils;
 import com.carenest.business.common.response.ResponseDto;
@@ -40,7 +40,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequestMapping("/api/v1/caregivers")
 public class CaregiverController {
 
-	private final CaregiverServiceImpl caregiverServiceImpl;
+	private final CaregiverService caregiverService;
 
 	@Qualifier("caregiverPresentationMapper")
 	private final CaregiverPresentationMapper presentationMapper;
@@ -51,14 +51,14 @@ public class CaregiverController {
 		@RequestBody CaregiverCreateRequestDTO createRequestDTO
 	){
 		CaregiverCreateRequestServiceDTO requestServiceDTO = presentationMapper.toCreateServiceDto(createRequestDTO);
-		CaregiverCreateResponseServiceDTO responseDTO = caregiverServiceImpl.createCaregiver(requestServiceDTO);
+		CaregiverCreateResponseServiceDTO responseDTO = caregiverService.createCaregiver(requestServiceDTO);
 		return ResponseDto.success("서비스 등록 요청이 접수되었습니다. 관리자 승인 후 활성화됩니다.",presentationMapper.toCreateResponseDto(responseDTO));
 	}
 
 	// Read (개인 조회)
 	@GetMapping("/{caregiverId}")
 	public ResponseDto<CaregiverReadResponseDTO> getCaregiverDetail(@PathVariable UUID caregiverId){
-		CaregiverReadResponseServiceDTO responseDTO = caregiverServiceImpl.getCaregiver(caregiverId);
+		CaregiverReadResponseServiceDTO responseDTO = caregiverService.getCaregiver(caregiverId);
 		return ResponseDto.success(presentationMapper.toReadResponseDto(responseDTO));
 	}
 
@@ -68,7 +68,7 @@ public class CaregiverController {
 		@PathVariable UUID caregiverId,
 		@RequestBody CaregiverUpdateRequestDTO requestDTO
 	){
-		CaregiverUpdateResponseServiceDTO responseDTO = caregiverServiceImpl.updateCaregiver(caregiverId,requestDTO);
+		CaregiverUpdateResponseServiceDTO responseDTO = caregiverService.updateCaregiver(caregiverId,requestDTO);
 		return ResponseDto.success("간병인 정보가 수정되었습니다.",presentationMapper.toUpdateResponseDto(responseDTO));
 	}
 
@@ -77,7 +77,7 @@ public class CaregiverController {
 	public ResponseDto<Void> deleteCaregiver(
 		@PathVariable UUID caregiverId
 	){
-		caregiverServiceImpl.deleteCaregiver(caregiverId);
+		caregiverService.deleteCaregiver(caregiverId);
 		return ResponseDto.success("간병인 정보가 삭제되었습니다.",null);
 	}
 
@@ -91,7 +91,7 @@ public class CaregiverController {
 		@RequestParam(required = false) String service
 	){
 		Pageable pageable = PageableUtils.customPageable(page,size,sortDirection,sortProperty);
-		Page<CaregiverSearchResponseServiceDTO> responseServiceDTO =  caregiverServiceImpl.searchCaregiver(location,service,pageable);
+		Page<CaregiverSearchResponseServiceDTO> responseServiceDTO =  caregiverService.searchCaregiver(location,service,pageable);
 
 		return ResponseDto.success("간병인 검색을 완료했습니다.", presentationMapper.toSearchResponseDto(responseServiceDTO));
 	}

--- a/caregiver-service/src/main/java/com/carenest/business/caregiverservice/presentation/controller/CaregiverInternalController.java
+++ b/caregiver-service/src/main/java/com/carenest/business/caregiverservice/presentation/controller/CaregiverInternalController.java
@@ -1,0 +1,36 @@
+package com.carenest.business.caregiverservice.presentation.controller;
+
+import java.util.UUID;
+
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.carenest.business.caregiverservice.application.service.CaregiverService;
+import com.carenest.business.common.response.ResponseDto;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/internal/v1/caregivers")
+public class CaregiverInternalController {
+
+	private final CaregiverService caregiverService;
+	// TODO: GateWay 에서 EndPoint 로 관리자 접근만 하게 적용
+
+
+	@PatchMapping("/{id}/status")
+	public ResponseDto<Void> updateCaregiverStatus(
+		@PathVariable UUID id,
+		@RequestParam boolean approvalStatusCheck
+	){
+		caregiverService.updateCaregiverStatus(id,approvalStatusCheck);
+		return ResponseDto.success(null);
+	};
+
+
+
+}


### PR DESCRIPTION
## PR Type  
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가  
- [ ] 버그 수정  
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)  
- [x] 코드 리팩토링  


## 변경 내용  

- **as-is**
  - `CaregiverInternalController`에서 `CaregiverServiceImpl`을 직접 의존하고 있었음
  - `Caregiver`의 `userId` 컬럼에 `unique` 제약 조건이 없음

- **to-be**
  -  사용자에서 승인을 해주는 api (feign용) 구현
  - `CaregiverServiceImpl` → `CaregiverService` 인터페이스로 의존성 주입 구조 개선 (느슨한 결합)
  - `Caregiver` Entity 내 `userId` 필드에 `unique = true` 제약 조건 추가하여 중복 방지


## 이슈 넘버  
- #44 

## 특이사항  
- 추후에 Gateway에서 `/internal/**` 경로에 대해 관리자 접근 제어 로직을 적용해야 함 (`TODO` 남겨둠)  
- `userId`는 비즈니스 상 중복되면 안 되는 값이므로 unique 제약은 명확한 방향성에 기반한 처리임