### PR TITLE
Feature/caregiver/top10

### DIFF
--- a/caregiver-service/build.gradle
+++ b/caregiver-service/build.gradle
@@ -53,6 +53,10 @@ dependencies {
     // kafka
     implementation 'org.springframework.kafka:spring-kafka'
 
+    // redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+
     implementation project(':common')
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/caregiver-service/src/main/java/com/carenest/business/caregiverservice/application/dto/response/BulkCaregiverTop10Response.java
+++ b/caregiver-service/src/main/java/com/carenest/business/caregiverservice/application/dto/response/BulkCaregiverTop10Response.java
@@ -1,0 +1,6 @@
+package com.carenest.business.caregiverservice.application.dto.response;
+
+import java.util.List;
+
+public record BulkCaregiverTop10Response(List<CaregiverGetTop10ResponseServiceDTO> responseDTOS) {
+}

--- a/caregiver-service/src/main/java/com/carenest/business/caregiverservice/application/dto/response/CaregiverGetTop10ResponseServiceDTO.java
+++ b/caregiver-service/src/main/java/com/carenest/business/caregiverservice/application/dto/response/CaregiverGetTop10ResponseServiceDTO.java
@@ -1,11 +1,10 @@
 package com.carenest.business.caregiverservice.application.dto.response;
 
-
 import java.util.UUID;
 
 import com.carenest.business.caregiverservice.domain.model.GenderType;
 
-public record CaregiverGetTop10ResponseServiceDTO(
+public record CaregiverGetTop10ResponseServiceDTO (
 	UUID id,
 	UUID userId,
 	String description,

--- a/caregiver-service/src/main/java/com/carenest/business/caregiverservice/application/service/CaregiverService.java
+++ b/caregiver-service/src/main/java/com/carenest/business/caregiverservice/application/service/CaregiverService.java
@@ -8,8 +8,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.carenest.business.caregiverservice.application.dto.request.CaregiverCreateRequestServiceDTO;
+import com.carenest.business.caregiverservice.application.dto.response.BulkCaregiverTop10Response;
 import com.carenest.business.caregiverservice.application.dto.response.CaregiverCreateResponseServiceDTO;
-import com.carenest.business.caregiverservice.application.dto.response.CaregiverGetTop10ResponseServiceDTO;
 import com.carenest.business.caregiverservice.application.dto.response.CaregiverReadResponseServiceDTO;
 import com.carenest.business.caregiverservice.application.dto.response.CaregiverSearchResponseServiceDTO;
 import com.carenest.business.caregiverservice.application.dto.response.CaregiverUpdateResponseServiceDTO;
@@ -34,7 +34,7 @@ public interface CaregiverService {
 
 	Page<CaregiverReadResponseServiceDTO> getCaregiverAll(Pageable pageable);
 
-	List<CaregiverGetTop10ResponseServiceDTO> getTop10Caregiver();
+	BulkCaregiverTop10Response getTop10Caregiver();
 
 	CaregiverReadResponseServiceDTO getCaregiverDetailUser(UUID caregiverId);
 }

--- a/caregiver-service/src/main/java/com/carenest/business/caregiverservice/config/CacheConfig.java
+++ b/caregiver-service/src/main/java/com/carenest/business/caregiverservice/config/CacheConfig.java
@@ -1,0 +1,40 @@
+package com.carenest.business.caregiverservice.config;
+
+import java.time.Duration;
+
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.CacheKeyPrefix;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.RedisSerializer;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+
+	@Bean
+	public RedisCacheManager cacheManager(
+		RedisConnectionFactory connectionFactory,
+		RedisSerializer<Object> redisSerializer
+	) {
+		RedisCacheConfiguration defaultCacheConfig = RedisCacheConfiguration
+			.defaultCacheConfig()
+			.disableCachingNullValues()
+			.entryTtl(Duration.ofSeconds(120))
+			.computePrefixWith(CacheKeyPrefix.simple())
+			.serializeValuesWith(
+				RedisSerializationContext.SerializationPair.fromSerializer(redisSerializer)
+			);
+
+
+		return RedisCacheManager
+			.builder(connectionFactory)
+			.cacheDefaults(defaultCacheConfig)
+			.build();
+	}
+}

--- a/caregiver-service/src/main/java/com/carenest/business/caregiverservice/config/RedisConfig.java
+++ b/caregiver-service/src/main/java/com/carenest/business/caregiverservice/config/RedisConfig.java
@@ -1,0 +1,45 @@
+package com.carenest.business.caregiverservice.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import com.carenest.business.caregiverservice.application.dto.response.BulkCaregiverTop10Response;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+@Configuration
+public class RedisConfig {
+	@Bean
+	public ObjectMapper objectMapper() {
+		ObjectMapper objectMapper = new ObjectMapper();
+		objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+		objectMapper.registerModule(new JavaTimeModule());
+		return objectMapper;
+	}
+
+	@Bean
+	@Primary
+	public RedisSerializer<Object> redisSerializer() {
+		return new GenericJackson2JsonRedisSerializer();
+	}
+
+	@Bean
+	public RedisTemplate<String, BulkCaregiverTop10Response> bulkProductRedisTemplate(
+		RedisConnectionFactory redisConnectionFactory
+	) {
+		RedisTemplate<String, BulkCaregiverTop10Response> template = new RedisTemplate<>();
+		template.setConnectionFactory(redisConnectionFactory);
+		template.setKeySerializer(new StringRedisSerializer());
+		template.setValueSerializer(new GenericJackson2JsonRedisSerializer(objectMapper()));
+		return template;
+	}
+
+
+}

--- a/caregiver-service/src/main/java/com/carenest/business/caregiverservice/presentation/controller/CaregiverController.java
+++ b/caregiver-service/src/main/java/com/carenest/business/caregiverservice/presentation/controller/CaregiverController.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.carenest.business.caregiverservice.application.dto.request.CaregiverCreateRequestServiceDTO;
+import com.carenest.business.caregiverservice.application.dto.response.BulkCaregiverTop10Response;
 import com.carenest.business.caregiverservice.application.dto.response.CaregiverCreateResponseServiceDTO;
 import com.carenest.business.caregiverservice.application.dto.response.CaregiverGetTop10ResponseServiceDTO;
 import com.carenest.business.caregiverservice.application.dto.response.CaregiverReadResponseServiceDTO;
@@ -134,10 +135,10 @@ public class CaregiverController {
 	}
 
 	@GetMapping("/rating/top")
-	public ResponseDto<List<CaregiverGetTop10ResponseDTO>> getTop10Caregiver()
+	public ResponseDto<BulkCaregiverTop10Response> getTop10Caregiver()
 	{
-		List<CaregiverGetTop10ResponseServiceDTO> responseServiceDTO = caregiverService.getTop10Caregiver();
-		return ResponseDto.success(presentationMapper.toGetTop10CaregiverDto(responseServiceDTO));
+		BulkCaregiverTop10Response responseServiceDTO = caregiverService.getTop10Caregiver();
+		return ResponseDto.success(responseServiceDTO);
 	}
 
 


### PR DESCRIPTION
## PR Type
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 변경 내용
- **as-is**
  - 매번 리뷰 서비스(Fеign client) 호출로 간병인 Top10 정보를 동기적으로 조회
  - 캐싱 및 Bulk 응답 구조가 없어 성능 병목 발생
- **to-be**
  - Redis, Cache 설정 추가 (RedisTemplate, RedisCacheManager 구성)  
  - `BulkCaregiverTop10Response` 템플릿 및 DTO 추가로 여러 정보를 한 번에 묶어 반환  
  - `@Cacheable` 적용(refactor)으로 인기 간병사 Top10 결과를 Redis에 캐싱  


## 이슈 넘버
- close #98

## 특이사항
- 기본 TTL 120초로 설정되어 있음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 인기 간병인 Top 10 조회 시 Redis 기반 캐싱이 적용되어 성능이 향상되었습니다.
    - 캐시 만료 시간은 120초로 설정되어 있습니다.

- **변경 사항**
    - 인기 간병인 Top 10 API의 응답 구조가 리스트에서 래퍼 객체(BulkCaregiverTop10Response)로 변경되었습니다.

- **기타**
    - Redis 및 캐싱 관련 설정이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->