### PR TITLE
Feature/#108 user auth deletion

### DIFF
--- a/common/src/main/java/com/carenest/business/common/annotation/AuthUserArgumentResolver.java
+++ b/common/src/main/java/com/carenest/business/common/annotation/AuthUserArgumentResolver.java
@@ -1,5 +1,7 @@
 package com.carenest.business.common.annotation;
 
+import com.carenest.business.common.exception.BaseException;
+import com.carenest.business.common.exception.CommonErrorCode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.core.MethodParameter;
@@ -29,7 +31,7 @@ public class AuthUserArgumentResolver implements HandlerMethodArgumentResolver {
         String encodedHeader = request.getHeader("AuthUser");
 
         if (encodedHeader == null) {
-            throw new IllegalStateException("AuthUser 헤더가 누락되었습니다.");
+            throw new BaseException(CommonErrorCode.MISSING_AUTH_HEADER);
         }
 
         byte[] decoded = Base64.getDecoder().decode(encodedHeader);

--- a/common/src/main/java/com/carenest/business/common/exception/CommonErrorCode.java
+++ b/common/src/main/java/com/carenest/business/common/exception/CommonErrorCode.java
@@ -14,7 +14,7 @@ public enum CommonErrorCode implements BaseErrorCode {
 	USER_NOT_FOUND("U-003", "사용자 정보를 찾을 수 없습니다.", HttpStatus.UNAUTHORIZED),
 	INVALID_USER_STATUS("U-004", "확인되지 않은 사용자입니다.", HttpStatus.UNAUTHORIZED),
 	INVALID_ROLE("U-005", "해당 작업을 수행할 수 없는 역할입니다.", HttpStatus.FORBIDDEN),
-	MISSING_AUTH_HEADER("C001", "AuthUser 헤더가 누락되었습니다.", HttpStatus.UNAUTHORIZED),
+	MISSING_AUTH_HEADER("C-001", "AuthUser 헤더가 누락되었습니다.", HttpStatus.UNAUTHORIZED),
 	;
 
 	private final String errorCode;

--- a/common/src/main/java/com/carenest/business/common/exception/CommonErrorCode.java
+++ b/common/src/main/java/com/carenest/business/common/exception/CommonErrorCode.java
@@ -14,6 +14,7 @@ public enum CommonErrorCode implements BaseErrorCode {
 	USER_NOT_FOUND("U-003", "사용자 정보를 찾을 수 없습니다.", HttpStatus.UNAUTHORIZED),
 	INVALID_USER_STATUS("U-004", "확인되지 않은 사용자입니다.", HttpStatus.UNAUTHORIZED),
 	INVALID_ROLE("U-005", "해당 작업을 수행할 수 없는 역할입니다.", HttpStatus.FORBIDDEN),
+	MISSING_AUTH_HEADER("C001", "AuthUser 헤더가 누락되었습니다.", HttpStatus.UNAUTHORIZED),
 	;
 
 	private final String errorCode;

--- a/user-service/src/main/java/com/carenest/business/userservice/application/service/UserService.java
+++ b/user-service/src/main/java/com/carenest/business/userservice/application/service/UserService.java
@@ -37,6 +37,11 @@ public class UserService {
 
     // 회원가입
     public SignupResponseDTO signup(SignupRequestDTO request) {
+        // ADMIN 권한으로 가입 시도 차단
+        if (request.getRole() == UserRole.ADMIN) {
+            throw new BaseException(UserErrorCode.NOT_ALLOWED_ROLE);
+        }
+
         // 이메일 중복 확인
         if (userRepository.existsByEmail(request.getEmail())) {
             throw new BaseException(UserErrorCode.DUPLICATED_EMAIL);

--- a/user-service/src/main/java/com/carenest/business/userservice/application/service/UserService.java
+++ b/user-service/src/main/java/com/carenest/business/userservice/application/service/UserService.java
@@ -72,6 +72,11 @@ public class UserService {
         User user = userRepository.findByUsername(request.getUsername())
                 .orElseThrow(() -> new BaseException(UserErrorCode.USERNAME_NOT_FOUND));
 
+        // 탈퇴한 유저 확인
+        if (user.getIsDeleted()) {
+            throw new BaseException(UserErrorCode.DELETED_USER);
+        }
+
         // 비밀번호 일치 확인 (암호화된 비밀번호 비교)
         if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
             throw new BaseException(UserErrorCode.INVALID_PASSWORD);

--- a/user-service/src/main/java/com/carenest/business/userservice/domain/exception/UserErrorCode.java
+++ b/user-service/src/main/java/com/carenest/business/userservice/domain/exception/UserErrorCode.java
@@ -14,7 +14,8 @@ public enum UserErrorCode implements BaseErrorCode {
     INVALID_PASSWORD("U-003", "비밀번호가 일치하지 않습니다.", HttpStatus.UNAUTHORIZED),
     INVALID_TOKEN("U-004", "유효하지 않은 토큰입니다.", HttpStatus.UNAUTHORIZED),
     DUPLICATED_USERNAME("U-005", "이미 사용 중인 아이디입니다.", HttpStatus.BAD_REQUEST),
-    USERNAME_NOT_FOUND("U-006", "존재하지 않는 사용자명입니다.", HttpStatus.NOT_FOUND);
+    USERNAME_NOT_FOUND("U-006", "존재하지 않는 사용자명입니다.", HttpStatus.NOT_FOUND),
+    DELETED_USER("U-007", "삭제된 사용자입니다.", HttpStatus.UNAUTHORIZED);
 
     private final String errorCode;
     private final String message;

--- a/user-service/src/main/java/com/carenest/business/userservice/domain/exception/UserErrorCode.java
+++ b/user-service/src/main/java/com/carenest/business/userservice/domain/exception/UserErrorCode.java
@@ -15,8 +15,8 @@ public enum UserErrorCode implements BaseErrorCode {
     INVALID_TOKEN("U-004", "유효하지 않은 토큰입니다.", HttpStatus.UNAUTHORIZED),
     DUPLICATED_USERNAME("U-005", "이미 사용 중인 아이디입니다.", HttpStatus.BAD_REQUEST),
     USERNAME_NOT_FOUND("U-006", "존재하지 않는 사용자명입니다.", HttpStatus.NOT_FOUND),
-    DELETED_USER("U-007", "삭제된 사용자입니다.", HttpStatus.UNAUTHORIZED);
-
+    DELETED_USER("U-007", "삭제된 사용자입니다.", HttpStatus.UNAUTHORIZED),
+    NOT_ALLOWED_ROLE("U-008", "ADMIN 권한으로는 회원가입할 수 없습니다.", HttpStatus.BAD_REQUEST);
     private final String errorCode;
     private final String message;
     private final HttpStatus status;


### PR DESCRIPTION
## PR Type
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 변경 내용
- **as-is**
  - (변경 전 설명을 여기에 작성)

- **to-be**
  - 탈퇴한 사용자면 로그인 안되게 처리
  - admin권한 가입 안되게 처리
  - AuthUser 헤더 누락 예외 API 응답에 포함되도록 처리

## 이슈 넘버
- close #108 

## 특이사항
<!-- 작업 중 특이사항이 생기면 적어주세요 -->
특이사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - "AuthUser" 헤더가 누락된 경우 표준화된 에러 코드와 메시지로 예외가 처리됩니다.

- **신규 기능**
  - 회원가입 시 ADMIN 권한으로 가입을 시도하면 제한됩니다.
  - 삭제된 사용자는 로그인할 수 없도록 차단됩니다.

- **개선 사항**
  - 관련 에러 코드와 메시지가 추가되어 오류 상황에 대한 안내가 명확해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->