### PR TITLE
Feature/caregiver/check

### DIFF
--- a/caregiver-service/src/main/java/com/carenest/business/caregiverservice/application/service/CaregiverApprovalService.java
+++ b/caregiver-service/src/main/java/com/carenest/business/caregiverservice/application/service/CaregiverApprovalService.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.UUID;
 
 import com.carenest.business.caregiverservice.infrastructure.client.dto.reservation.ReservationAcceptRequest;
+import com.carenest.business.caregiverservice.infrastructure.client.dto.reservation.ReservationRejectRequest;
 import com.carenest.business.caregiverservice.presentation.dto.response.PendingApprovalResponse;
 import com.carenest.business.common.event.caregiver.CaregiverPendingEvent;
 
@@ -14,4 +15,6 @@ public interface CaregiverApprovalService {
 	List<PendingApprovalResponse> getPendingApprovals(UUID userId);
 
 	void acceptCaregiverReservation(UUID reservationId, ReservationAcceptRequest request, UUID userId);
+
+	void rejectCaregiverReservation(UUID reservationId, ReservationRejectRequest request, UUID userId);
 }

--- a/caregiver-service/src/main/java/com/carenest/business/caregiverservice/application/service/CaregiverApprovalService.java
+++ b/caregiver-service/src/main/java/com/carenest/business/caregiverservice/application/service/CaregiverApprovalService.java
@@ -3,6 +3,7 @@ package com.carenest.business.caregiverservice.application.service;
 import java.util.List;
 import java.util.UUID;
 
+import com.carenest.business.caregiverservice.infrastructure.client.dto.reservation.ReservationAcceptRequest;
 import com.carenest.business.caregiverservice.presentation.dto.response.PendingApprovalResponse;
 import com.carenest.business.common.event.caregiver.CaregiverPendingEvent;
 
@@ -11,4 +12,6 @@ public interface CaregiverApprovalService {
 	void createCaregiverApproval(CaregiverPendingEvent event);
 
 	List<PendingApprovalResponse> getPendingApprovals(UUID userId);
+
+	void acceptCaregiverReservation(UUID reservationId, ReservationAcceptRequest request, UUID userId);
 }

--- a/caregiver-service/src/main/java/com/carenest/business/caregiverservice/application/service/CaregiverApprovalServiceImpl.java
+++ b/caregiver-service/src/main/java/com/carenest/business/caregiverservice/application/service/CaregiverApprovalServiceImpl.java
@@ -11,11 +11,14 @@ import com.carenest.business.caregiverservice.domain.model.CaregiverApproval;
 import com.carenest.business.caregiverservice.exception.CaregiverException;
 import com.carenest.business.caregiverservice.exception.ErrorCode;
 import com.carenest.business.caregiverservice.infrastructure.client.ReservationClient;
+import com.carenest.business.caregiverservice.infrastructure.client.dto.reservation.ReservationAcceptRequest;
 import com.carenest.business.caregiverservice.infrastructure.client.dto.reservation.ReservationResponse;
 import com.carenest.business.caregiverservice.infrastructure.repository.CaregiverApprovalRepository;
 import com.carenest.business.caregiverservice.infrastructure.repository.CaregiverRepository;
 import com.carenest.business.caregiverservice.presentation.dto.response.PendingApprovalResponse;
 import com.carenest.business.common.event.caregiver.CaregiverPendingEvent;
+import com.carenest.business.common.exception.BaseException;
+import com.carenest.business.common.exception.CommonErrorCode;
 
 import feign.FeignException;
 import lombok.RequiredArgsConstructor;
@@ -75,5 +78,26 @@ public class CaregiverApprovalServiceImpl implements CaregiverApprovalService{
 					throw  new CaregiverException(ErrorCode.EXTERNAL_API_ERROR);
 				}
 			}).toList();
+	}
+
+	@Override
+	public void acceptCaregiverReservation(UUID reservationId, ReservationAcceptRequest request, UUID userId) {
+		try {
+
+			// 1. 간병인 정보 조회
+			Caregiver caregiver = caregiverRepository.findByUserId(userId)
+				.orElseThrow(() -> new CaregiverException(ErrorCode.NOT_FOUND));
+
+			// 2. 간병인 검증
+			CaregiverApproval caregiverApproval = caregiverApprovalRepository.findByReservationIdAndCaregiverId(reservationId, caregiver.getId())
+				.orElseThrow(() -> new BaseException(CommonErrorCode.FORBIDDEN));
+
+			reservationClient.acceptReservation(caregiverApproval.getReservationId(),request);
+			log.info("예약 수락 요청이 완료되었습니다.");
+
+		} catch (FeignException e){
+			log.warn("예약 수락 실패: userId={}, error={}", userId, e.getMessage());
+			throw  new CaregiverException(ErrorCode.EXTERNAL_API_ERROR);
+		}
 	}
 }

--- a/caregiver-service/src/main/java/com/carenest/business/caregiverservice/application/service/CaregiverApprovalServiceImpl.java
+++ b/caregiver-service/src/main/java/com/carenest/business/caregiverservice/application/service/CaregiverApprovalServiceImpl.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.carenest.business.caregiverservice.domain.model.Caregiver;
 import com.carenest.business.caregiverservice.domain.model.CaregiverApproval;
+import com.carenest.business.caregiverservice.domain.model.CaregiverStatus;
 import com.carenest.business.caregiverservice.exception.CaregiverException;
 import com.carenest.business.caregiverservice.exception.ErrorCode;
 import com.carenest.business.caregiverservice.infrastructure.client.ReservationClient;
@@ -82,6 +83,7 @@ public class CaregiverApprovalServiceImpl implements CaregiverApprovalService{
 	}
 
 	@Override
+	@Transactional
 	public void acceptCaregiverReservation(UUID reservationId, ReservationAcceptRequest request, UUID userId) {
 		try {
 
@@ -94,6 +96,7 @@ public class CaregiverApprovalServiceImpl implements CaregiverApprovalService{
 				.orElseThrow(() -> new BaseException(CommonErrorCode.FORBIDDEN));
 
 			reservationClient.acceptReservation(caregiverApproval.getReservationId(),request);
+			caregiver.updateStatus(CaregiverStatus.IN_PROGRESS);
 			log.info("예약 수락 요청이 완료되었습니다.");
 
 		} catch (FeignException e){
@@ -103,6 +106,7 @@ public class CaregiverApprovalServiceImpl implements CaregiverApprovalService{
 	}
 
 	@Override
+	@Transactional
 	public void rejectCaregiverReservation(UUID reservationId, ReservationRejectRequest request, UUID userId) {
 		try {
 			// 1. 간병인 정보 조회

--- a/caregiver-service/src/main/java/com/carenest/business/caregiverservice/domain/model/Caregiver.java
+++ b/caregiver-service/src/main/java/com/carenest/business/caregiverservice/domain/model/Caregiver.java
@@ -86,6 +86,12 @@ public class Caregiver extends BaseEntity {
 	@Enumerated(EnumType.STRING)
 	private GenderType gender;
 
+	@Column(nullable = false)
+	@Enumerated(EnumType.STRING)
+	@Builder.Default
+	private CaregiverStatus status = CaregiverStatus.AVAILABLE;
+
+
 	public void clearCategoryServices() {
 		this.caregiverCategoryServices.clear();
 	}
@@ -100,5 +106,9 @@ public class Caregiver extends BaseEntity {
 
 	public void updateRating(double rating) {
 		this.rating = rating;
+	}
+
+	public void updateStatus(CaregiverStatus status) {
+		this.status = status;
 	}
 }

--- a/caregiver-service/src/main/java/com/carenest/business/caregiverservice/domain/model/CaregiverStatus.java
+++ b/caregiver-service/src/main/java/com/carenest/business/caregiverservice/domain/model/CaregiverStatus.java
@@ -1,0 +1,6 @@
+package com.carenest.business.caregiverservice.domain.model;
+
+public enum CaregiverStatus {
+	AVAILABLE,      // 예약 가능 (활동 가능)
+	IN_PROGRESS    // 간병 중 (서비스 수행 중)
+}

--- a/caregiver-service/src/main/java/com/carenest/business/caregiverservice/infrastructure/client/ReservationClient.java
+++ b/caregiver-service/src/main/java/com/carenest/business/caregiverservice/infrastructure/client/ReservationClient.java
@@ -4,18 +4,30 @@ import java.util.UUID;
 
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 
 import com.carenest.business.caregiverservice.config.FeignConfig;
+import com.carenest.business.caregiverservice.infrastructure.client.dto.reservation.ReservationAcceptRequest;
+import com.carenest.business.caregiverservice.infrastructure.client.dto.reservation.ReservationRejectRequest;
 import com.carenest.business.caregiverservice.infrastructure.client.dto.reservation.ReservationResponse;
 import com.carenest.business.common.response.ResponseDto;
 
-@FeignClient(
-	name = "reservation-service",
-	configuration = FeignConfig.class
-)
+import jakarta.validation.Valid;
+
+@FeignClient(name = "reservation-service", configuration = FeignConfig.class)
 public interface ReservationClient {
 
 	@GetMapping("/api/v1/internal/reservations/{reservationId}")
 	ResponseDto<ReservationResponse> getReservationDetails(@PathVariable UUID reservationId);
+
+	@PatchMapping("/reservations/{reservationId}/accept")
+	ResponseDto<ReservationResponse> acceptReservation(@PathVariable UUID reservationId,
+		@RequestBody @Valid ReservationAcceptRequest request);
+
+	@PatchMapping("/reservations/{reservationId}/reject")
+	ResponseDto<ReservationResponse> rejectReservation(@PathVariable UUID reservationId,
+		@RequestBody @Valid ReservationRejectRequest request);
 }
+

--- a/caregiver-service/src/main/java/com/carenest/business/caregiverservice/infrastructure/client/ReservationClient.java
+++ b/caregiver-service/src/main/java/com/carenest/business/caregiverservice/infrastructure/client/ReservationClient.java
@@ -4,8 +4,8 @@ import java.util.UUID;
 
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
 import com.carenest.business.caregiverservice.config.FeignConfig;
@@ -22,11 +22,11 @@ public interface ReservationClient {
 	@GetMapping("/api/v1/internal/reservations/{reservationId}")
 	ResponseDto<ReservationResponse> getReservationDetails(@PathVariable UUID reservationId);
 
-	@PatchMapping("/reservations/{reservationId}/accept")
+	@PostMapping("/api/v1/internal/reservations/{reservationId}/accept")
 	ResponseDto<ReservationResponse> acceptReservation(@PathVariable UUID reservationId,
 		@RequestBody @Valid ReservationAcceptRequest request);
 
-	@PatchMapping("/reservations/{reservationId}/reject")
+	@PostMapping("/api/v1/internal/reservations/{reservationId}/reject")
 	ResponseDto<ReservationResponse> rejectReservation(@PathVariable UUID reservationId,
 		@RequestBody @Valid ReservationRejectRequest request);
 }

--- a/caregiver-service/src/main/java/com/carenest/business/caregiverservice/infrastructure/client/dto/reservation/ReservationAcceptRequest.java
+++ b/caregiver-service/src/main/java/com/carenest/business/caregiverservice/infrastructure/client/dto/reservation/ReservationAcceptRequest.java
@@ -1,0 +1,17 @@
+package com.carenest.business.caregiverservice.infrastructure.client.dto.reservation;
+
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReservationAcceptRequest {
+
+	@Size(max = 255, message = "간병인 메모는 최대 255자까지 입력 가능합니다")
+	private String caregiverNote;
+}

--- a/caregiver-service/src/main/java/com/carenest/business/caregiverservice/infrastructure/client/dto/reservation/ReservationRejectRequest.java
+++ b/caregiver-service/src/main/java/com/carenest/business/caregiverservice/infrastructure/client/dto/reservation/ReservationRejectRequest.java
@@ -1,0 +1,22 @@
+package com.carenest.business.caregiverservice.infrastructure.client.dto.reservation;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReservationRejectRequest {
+
+	@NotBlank(message = "거절 사유는 필수 입력 항목입니다")
+	@Size(max = 255, message = "거절 사유는 최대 255자까지 입력 가능합니다")
+	private String rejectionReason;
+
+	@Size(max = 255, message = "대안 제안은 최대 255자까지 입력 가능합니다")
+	private String suggestedAlternative;
+}

--- a/caregiver-service/src/main/java/com/carenest/business/caregiverservice/infrastructure/repository/CaregiverApprovalRepository.java
+++ b/caregiver-service/src/main/java/com/carenest/business/caregiverservice/infrastructure/repository/CaregiverApprovalRepository.java
@@ -1,6 +1,7 @@
 package com.carenest.business.caregiverservice.infrastructure.repository;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -12,4 +13,6 @@ import com.carenest.business.caregiverservice.domain.model.CaregiverApproval;
 public interface CaregiverApprovalRepository extends JpaRepository<CaregiverApproval, UUID> {
 
 	List<CaregiverApproval> findByCaregiverId(UUID caregiverId);
+
+	Optional<CaregiverApproval> findByReservationIdAndCaregiverId(UUID reservationId, UUID id);
 }

--- a/caregiver-service/src/main/java/com/carenest/business/caregiverservice/infrastructure/repository/querydsl/CaregiverRepositoryImpl.java
+++ b/caregiver-service/src/main/java/com/carenest/business/caregiverservice/infrastructure/repository/querydsl/CaregiverRepositoryImpl.java
@@ -15,6 +15,7 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 
+import com.carenest.business.caregiverservice.domain.model.CaregiverStatus;
 import com.carenest.business.caregiverservice.domain.model.GenderType;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
@@ -40,7 +41,8 @@ public class CaregiverRepositoryImpl implements CaregiverCustomRepository {
 			.where(
 				location != null ? caregiverCategoryLocation.categoryLocation.name.eq(location) : null,
 				service != null ? caregiverCategoryService.categoryService.name.eq(service) : null,
-				caregiver.approvalStatus.eq(true)
+				caregiver.approvalStatus.eq(true),
+				caregiver.status.eq(CaregiverStatus.AVAILABLE)
 			)
 			.offset(pageable.getOffset())
 			.limit(pageable.getPageSize());
@@ -61,7 +63,8 @@ public class CaregiverRepositoryImpl implements CaregiverCustomRepository {
 			.where(
 				location != null ? caregiverCategoryLocation.categoryLocation.name.eq(location) : null,
 				service != null ? caregiverCategoryService.categoryService.name.eq(service) : null,
-				caregiver.approvalStatus.eq(true)
+				caregiver.approvalStatus.eq(true),
+				caregiver.status.eq(CaregiverStatus.AVAILABLE)
 			);
 
 		return new PageImpl<>(caregivers, pageable, caregiverCountQuery.fetchOne());

--- a/caregiver-service/src/main/java/com/carenest/business/caregiverservice/presentation/controller/CaregiverApprovalController.java
+++ b/caregiver-service/src/main/java/com/carenest/business/caregiverservice/presentation/controller/CaregiverApprovalController.java
@@ -1,12 +1,17 @@
 package com.carenest.business.caregiverservice.presentation.controller;
 
 import java.util.List;
+import java.util.UUID;
 
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.carenest.business.caregiverservice.application.service.CaregiverApprovalService;
+import com.carenest.business.caregiverservice.infrastructure.client.dto.reservation.ReservationAcceptRequest;
 import com.carenest.business.caregiverservice.presentation.dto.response.PendingApprovalResponse;
 import com.carenest.business.common.annotation.AuthUser;
 import com.carenest.business.common.annotation.AuthUserInfo;
@@ -27,6 +32,16 @@ public class CaregiverApprovalController {
 	){
 		List<PendingApprovalResponse> responses = caregiverApprovalService.getPendingApprovals(authUserInfo.getUserId());
 		return ResponseDto.success(responses);
+	}
+
+	@PatchMapping("/{reservationId}/accept")
+	public ResponseDto<Void> acceptCaregiverReservation(
+		@PathVariable UUID reservationId,
+		@RequestBody ReservationAcceptRequest request,
+		@AuthUser AuthUserInfo authUserInfo
+	){
+		caregiverApprovalService.acceptCaregiverReservation(reservationId,request,authUserInfo.getUserId());
+		return ResponseDto.success("예약을 수락하셨습니다.");
 	}
 
 }

--- a/caregiver-service/src/main/java/com/carenest/business/caregiverservice/presentation/controller/CaregiverApprovalController.java
+++ b/caregiver-service/src/main/java/com/carenest/business/caregiverservice/presentation/controller/CaregiverApprovalController.java
@@ -52,7 +52,7 @@ public class CaregiverApprovalController {
 		@AuthUser AuthUserInfo authUserInfo
 	){
 		caregiverApprovalService.rejectCaregiverReservation(reservationId,request,authUserInfo.getUserId());
-		return ResponseDto.success("예약을 수락하셨습니다.");
+		return ResponseDto.success("예약을 거절하셨습니다.");
 	}
 
 }

--- a/caregiver-service/src/main/java/com/carenest/business/caregiverservice/presentation/controller/CaregiverApprovalController.java
+++ b/caregiver-service/src/main/java/com/carenest/business/caregiverservice/presentation/controller/CaregiverApprovalController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.carenest.business.caregiverservice.application.service.CaregiverApprovalService;
 import com.carenest.business.caregiverservice.infrastructure.client.dto.reservation.ReservationAcceptRequest;
+import com.carenest.business.caregiverservice.infrastructure.client.dto.reservation.ReservationRejectRequest;
 import com.carenest.business.caregiverservice.presentation.dto.response.PendingApprovalResponse;
 import com.carenest.business.common.annotation.AuthUser;
 import com.carenest.business.common.annotation.AuthUserInfo;
@@ -41,6 +42,16 @@ public class CaregiverApprovalController {
 		@AuthUser AuthUserInfo authUserInfo
 	){
 		caregiverApprovalService.acceptCaregiverReservation(reservationId,request,authUserInfo.getUserId());
+		return ResponseDto.success("예약을 수락하셨습니다.");
+	}
+
+	@PatchMapping("/{reservationId}/reject")
+	public ResponseDto<Void> rejectCaregiverReservation(
+		@PathVariable UUID reservationId,
+		@RequestBody ReservationRejectRequest request,
+		@AuthUser AuthUserInfo authUserInfo
+	){
+		caregiverApprovalService.rejectCaregiverReservation(reservationId,request,authUserInfo.getUserId());
 		return ResponseDto.success("예약을 수락하셨습니다.");
 	}
 

--- a/reservation-service/src/main/java/com/carenest/business/reservationservice/presentation/controller/ReservationInternalController.java
+++ b/reservation-service/src/main/java/com/carenest/business/reservationservice/presentation/controller/ReservationInternalController.java
@@ -24,7 +24,7 @@ public class ReservationInternalController {
         return ResponseDto.success("예약 정보 조회 성공", reservation);
     }
 
-    @PatchMapping("/reservations/{reservationId}/accept")
+    @PostMapping("/reservations/{reservationId}/accept")
     public ResponseDto<ReservationResponse> acceptReservation(
             @PathVariable UUID reservationId,
             @RequestBody @Valid ReservationAcceptRequest request) {
@@ -37,7 +37,7 @@ public class ReservationInternalController {
         return ResponseDto.success("예약이 성공적으로 수락되었습니다.", response);
     }
 
-    @PatchMapping("/reservations/{reservationId}/reject")
+    @PostMapping("/reservations/{reservationId}/reject")
     public ResponseDto<ReservationResponse> rejectReservation(
             @PathVariable UUID reservationId,
             @RequestBody @Valid ReservationRejectRequest request) {


### PR DESCRIPTION
## PR Type
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## 변경 내용

- **as-is**
  - 간병인 상태가 구체적으로 정의되어 있지 않아, 예약 중인지 여부를 판단할 수 없었음
  - 예약 수락/거절 API가 ReservationClient에 정의되어 있지 않았고, HTTP PATCH 메서드 사용 시 오류 발생

- **to-be**
  - `CaregiverStatus` enum에 `IN_PROGRESS` 상태 추가
  - 해당 상태의 간병인은 조회에서 제외되도록 쿼리 작성
  - `ReservationClient`에 수락/거절 API (`acceptReservation`, `rejectReservation`) 추가
  - Feign이 PATCH를 지원하지 않아 해당 엔드포인트를 POST 방식으로 수정
  - 간병인이 예약을 수락/거절할 수 있는 서비스 기능 추가 (동기 방식으로 예약 서비스 호출)


## 이슈 넘버
- close #127


## 특이사항
- FeignClient가 기본적으로 PATCH를 지원하지 않아 엔드포인트를 POST로 변경하여 해결
- 간병인 상태 관리(`IN_PROGRESS`)가 추가되면서 예약 수락 로직에서 상태 업데이트 필요
- 추후 예약 종료 후 상태를 다시 `AVAILABLE`로 바꿔주는 로직도 필요할 수 있음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 간병인이 예약을 수락하거나 거절할 수 있는 기능이 추가되었습니다.
  - 간병인 상태(AVAILABLE, IN_PROGRESS) 관리 기능이 도입되었습니다.

- **API 변경**
  - 예약 수락/거절 관련 엔드포인트가 PATCH에서 POST 방식으로 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->